### PR TITLE
Prevent libpq from being removed post pip installations

### DIFF
--- a/examples/kube/docker/Dockerfile
+++ b/examples/kube/docker/Dockerfile
@@ -36,12 +36,12 @@ RUN set -ex \
         libsasl2-dev \
         libssl-dev \
         libffi-dev \
-        libpq-dev \
     ' \
     && apt-get update -yqq \
     && apt-get upgrade -yqq \
     && apt-get install -yqq --no-install-recommends \
         $buildDeps \
+        libpq-dev \
         freetds-bin \
         build-essential \
         default-libmysqlclient-dev \

--- a/examples/minikube/docker/Dockerfile
+++ b/examples/minikube/docker/Dockerfile
@@ -36,12 +36,12 @@ RUN set -ex \
         libsasl2-dev \
         libssl-dev \
         libffi-dev \
-        libpq-dev \
     ' \
     && apt-get update -yqq \
     && apt-get upgrade -yqq \
     && apt-get install -yqq --no-install-recommends \
         $buildDeps \
+        libpq-dev \
         freetds-bin \
         build-essential \
         default-libmysqlclient-dev \


### PR DESCRIPTION
libpq is required at runtime for Python psycopg. Without it, `airflow-scheduler` and `airflow-web` deployment would continue to fail.