### PR TITLE
Fixed an issue so Airflow kube workers can get and use the FERNET_KEY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 *crunch*
 *_complete.yaml
 airflow/charts
+airflow_vars.env
+secrets.env
+secrets.json
+secrets_old.json
+google_app_creds.json
+invoice-processing-ocr-creds.json
+ocr-compress.json

--- a/airflow/templates/configmaps.yaml
+++ b/airflow/templates/configmaps.yaml
@@ -160,7 +160,9 @@ data:
 
     [kubernetes_secrets]
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = {{ template "airflow.fullname" $ }}-env=AIRFLOW__CORE__SQL_ALCHEMY_CONN
+    AIRFLOW__CORE__FERNET_KEY = {{ template "airflow.fullname" $ }}-env=FERNET_KEY
     AIRFLOW_HOME = {{ template "airflow.fullname" $ }}-env=AIRFLOW_HOME
+    FERNET_KEY = {{ template "airflow.fullname" $ }}-env=FERNET_KEY
     {{- range $setting, $option := .Values.airflow.config }}
     {{ $setting }} = {{ template "airflow.fullname" $ }}-env={{ $setting }}
     {{- end }}

--- a/airflow/templates/configmaps.yaml
+++ b/airflow/templates/configmaps.yaml
@@ -122,7 +122,7 @@ data:
     worker_container_tag = {{ .Values.airflow.image.tag }}
     worker_container_image_pull_policy = {{ .Values.airflow.image.pull_policy }}
     worker_dags_folder = /usr/local/airflow/dags
-    delete_worker_pods = true
+    delete_worker_pods = True
     {{- if .Values.airflow.dags.persistence.enabled }}
     {{- if .Values.airflow.dags.persistence.existingClaim }}
     dags_volume_claim = {{ .Values.airflow.dags.persistence.existingClaim }}

--- a/airflow/templates/scheduler.yaml
+++ b/airflow/templates/scheduler.yaml
@@ -8,6 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  nodeSelector:
+    airflow: true
   replicas: 1
   serviceAccountName: {{ template "airflow.fullname" . }}-cluster-access
   strategy:

--- a/airflow/templates/services.yaml
+++ b/airflow/templates/services.yaml
@@ -8,6 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  nodeSelector:
+    airflow: true
   type: {{ .Values.airflow.service.type }}
   selector:
     app: {{ template "airflow.name" . }}-web

--- a/airflow/templates/webserver.yaml
+++ b/airflow/templates/webserver.yaml
@@ -8,6 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  nodeSelector:
+    airflow: true
   replicas: 1
   strategy:
     # Smooth rolling update of the Web UI

--- a/airflow/values.yaml
+++ b/airflow/values.yaml
@@ -11,7 +11,7 @@ airflow:
   ## Generate fernet_key with:
   ##    python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ## fernet_key: ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD
-  fernet_key: "abcdefghijklmnopqrstuvwxyzABCDEFG1234567890="
+  fernet_key: "wEyDkTXKeSZNfNMhwrPMjSPY-E4UJEx8GtN5QV3nTkM="
   service:
     type: NodePort
   ##
@@ -98,9 +98,9 @@ airflow:
     ##
     ## Configure Git repository to fetch DAGs
     git:
-      url: https://github.com/apache/airflow
+      url: https://github.com/dafrenchyman/kube
       branch: master
-      subpath: dags
+      subpath: .
       ##
       ## Number of seconds to wait between git synchronizations
       wait: 60
@@ -109,12 +109,12 @@ airflow:
     enabled: false
     # Initial rbac users can be defined here as a list of maps.
     users:
-    - firstname: "Jon"
-      lastname: "Doe"
-      email: "jdoe@example.com"
-      username: "jdoe"
+    - firstname: "AI"
+      lastname: "Tiger"
+      email: "ai.of.the.tiger@appfolio.com"
+      username: "admin"
       role: "Admin"
-      password: "JDoe123"
+      password: "airflow123"
     webserver_config: |
       # -*- coding: utf-8 -*-
       #

--- a/examples/kube/docker/Dockerfile
+++ b/examples/kube/docker/Dockerfile
@@ -8,6 +8,8 @@
 # with a minor change to have git available. Please start from the original Dockerfile
 # for your own setup.
 
+# Further modified to include some extra libraries
+
 FROM python:3.6-slim
 LABEL maintainer="Puckel_"
 
@@ -50,17 +52,22 @@ RUN set -ex \
         rsync \
         netcat \
         locales \
+        libpq5 \
         git \
     && sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && pip install -U pip setuptools wheel \
+    && pip install cryptography \
+    && pip install flask_bcrypt \
+    && pip install psycopg2-binary==2.7.4  \
     && pip install pytz \
     && pip install pyOpenSSL \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
-    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
-    && pip install 'redis>=2.10.5,<3' \
+    && pip install 'slackclient>=1.0.0,<2.0.0' \
+    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh,slack${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
+    && pip install 'redis==3.2.1' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+##############################################################
+# This script installs Airflow with the Kubernetes Executor
+# onto a cluster via a Helm Chart
+#
+# OSX instructions:
+# Install docker and enable kubernetes:
+#
+# https://docs.docker.com/docker-for-mac/install/
+#
+# enable kubernetes:
+# - Top right go Docker -> "Preferences..." -> "Kubernetes"
+#   - Check mark "enable kubernetes", "Show system containers"
+#   - Select "kubernetes" instead of swarm
+#
+# Make sure python is install along with cryptography
+#   pip3 install cryptography
+#
+##############################################################
+
+NAMESPACE=$1
+: "${NAMESPACE:="default"}"
+BUILD_DOCKER="TRUE"
+
+##############################################################
+# Build the docker image script
+##############################################################
+build_docker() {
+  ./examples/kube/docker/build-docker.sh dafrenchyman/docker-airflow 1.10.2
+  docker push dafrenchyman/docker-airflow:1.10.2
+}
+
+##############################################################
+# Check everything is up and running
+# Install helm if not running
+##############################################################
+setup () {
+  # Check docker is running
+  which docker
+  if [ $? -eq 0 ]
+  then
+      echo "Docker installed"
+  else
+      exit 1
+  fi
+
+  # Check node is up
+  [[ $(kubectl get nodes | grep Ready) ]] || exit 1
+
+  # Install Helm
+  brew list kubernetes-helm || brew install kubernetes-helm
+
+  # Setup namespace
+  kubectl create namespace ${NAMESPACE}
+
+  # Setup NFS Log mount
+  ./nfs/create_nfs_logs.sh ${NAMESPACE}
+
+  ##########################################
+  # Install Tiller on the cluster
+  ##########################################
+  kubectl apply -f airflow/tiller.yaml
+  helm init --service-account tiller
+
+  echo "Waiting for tiller to come up (30 seconds)"
+  sleep 30
+}
+
+##############################################################
+# Function to install airflow via helm
+##############################################################
+install_airflow () {
+
+  # add a service account within a namespace for airflow
+  # This will allow the worker nodes to spawn pods
+  kubectl --namespace ${NAMESPACE} create sa airflow
+  kubectl --namespace ${NAMESPACE} create sa default
+
+  # Create service accounts
+  kubectl create clusterrolebinding ${NAMESPACE}:airflow \
+    --clusterrole cluster-admin \
+    --serviceaccount=${NAMESPACE}:airflow \
+    --namespace=${NAMESPACE}
+
+  kubectl create clusterrolebinding ${NAMESPACE}:default \
+    --clusterrole cluster-admin \
+    --serviceaccount=${NAMESPACE}:default \
+    --namespace=${NAMESPACE}
+
+  # Generate a fernet key
+  FERNET_KEY=`python3 -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"`
+
+  helm upgrade --install airflow airflow/ \
+    --namespace ${NAMESPACE} \
+    --values ./install/custom_values.yaml \
+    --set airflow.fernet_key="$FERNET_KEY"
+
+  # Wait a few seconds
+  sleep 5
+
+  # Make sure all services are up (All airflow services return 1 before moving on)
+  is_done="FALSE"
+  while [ "$is_done" != "TRUE" ]
+  do
+    airflow_pods_list=`kubectl --namespace ${NAMESPACE} get pods | grep airflow | awk '{ print $3 }'`
+    is_done="TRUE"
+    while read -r line; do
+      if [ "$line" != "Running" ]
+      then
+        echo "Services are not up yet (waiting 10 seconds)"
+        is_done="FALSE"
+        break
+      fi
+    done <<< "$airflow_pods_list"
+    sleep 10
+  done
+
+  ##############################################################
+  # Create Secrets on the cluster
+  ##############################################################
+
+  # Google credential secrets as file
+  kubectl --namespace ${NAMESPACE} \
+    create secret generic invoice-processing-env \
+    --from-env-file=./secrets.env
+  kubectl --namespace ${NAMESPACE} \
+    create secret generic invoice-processing-google-app-cred \
+    --from-file=./google_app_creds.json
+  kubectl --namespace ${NAMESPACE} \
+    create secret generic invoice-processing-invoice-processing-ocr-creds \
+    --from-file=./invoice-processing-ocr-creds.json
+  kubectl --namespace ${NAMESPACE} \
+    create secret generic invoice-processing-ocr-compress \
+    --from-file=./ocr-compress.json
+
+  # Google credential secrets for pod ImagePullSecrets (still need to figure this out)
+  DOCKER_REG="FALSE"
+  if [ "DOCKER_REG" == "TRUE" ]; then
+    kubectl create secret docker-registry gcr-json-key \
+      --docker-server=http://gcr.io \
+      --docker-username=_json_key \
+      --docker-password="$(cat google_app_creds.json)" \
+      --docker-email=any@validemail.com
+
+    # Attach ImagePullSecrets to pod serviceaccount
+    kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "gcr-json-key"}]}'
+  fi
+
+  ##############################################################
+  # Test connecting to cluster
+  ##############################################################
+  APISERVER=$(kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " ")
+  TOKEN=$(kubectl describe secret $(kubectl get secrets | grep ^default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d " ")
+  curl $APISERVER/api --header "Authorization: Bearer $TOKEN" --insecure
+
+  ##############################################################
+  # Enable access to the web GUI
+  #   Helpful instructions:
+  #   https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/
+  ##############################################################
+
+  # Get the name of the airflow pod
+  ./install/port_forwarding.sh ${NAMESPACE}
+
+  echo "Airflow is now up and running on: http://localhost:8080/"
+}
+
+build_docker
+setup
+install_airflow
+
+##############################################################
+# Extras
+##############################################################
+
+#
+# Enable Kubernetes web GUI
+# Info: https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/
+#
+#kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
+#kubectl proxy
+
+# Example of how to enter a running container
+# kubectl exec -it <POD_NAME> -- /bin/bash

--- a/install/add_variables_connections.sh
+++ b/install/add_variables_connections.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+NAMESPACE=default
+
+# Get Airflow web pod to set variables
+export AIRFLOW_POD=`kubectl --namespace ${NAMESPACE} get pods | grep airflow-web -m 1| cut -f1 -d' '`
+
+# Source env we will need
+source airflow_vars.env
+
+add_variables () {
+    KEY=$1
+    VALUE=$2
+    kubectl --namespace ${NAMESPACE} exec ${AIRFLOW_POD} -c webserver -- sh -c "/entrypoint.sh airflow variables --set ${KEY} ${VALUE}"
+}
+
+######################################
+# Add variables to airflow
+######################################
+
+# Overall
+add_variables kube_namespace default
+
+# Amount
+add_variables invoice_processing_amount_counter 0
+add_variables invoice_processing_amount_sha 453daad491d5a905fa654b86fe584787466735ba
+add_variables invoice_processing_amount_vhosts "[\\\"actprop\\\", \\\"archerinvestment\\\", \\\"archways\\\", \\\"arthurthomas\\\", \\\"athomeapartments\\\", \\\"austincapitaladvisors\\\", \\\"az1strealty\\\", \\\"baboudjianprop\\\", \\\"bandz\\\", \\\"barinvest2\\\", \\\"bayapartment\\\", \\\"blanchardandcalhoun\\\", \\\"bluediamond\\\", \\\"blumaxpartners\\\", \\\"bmoremanagement\\\", \\\"bridlewoodrecompany\\\", \\\"bristleconemgmt\\\", \\\"brokerscomm\\\", \\\"brownstonemgt\\\", \\\"bumanagement\\\", \\\"burlingtonrentals\\\", \\\"calson\\\", \\\"carsonproperties\\\", \\\"cavaliermgmt\\\", \\\"centerpoint2\\\", \\\"century21battlefield\\\", \\\"cfisandiego\\\", \\\"circum\\\", \\\"cityrentals\\\", \\\"coastlineequity\\\", \\\"coastmanagement\\\", \\\"collegehousingnw\\\", \\\"compasscommercial\\\", \\\"conradpm\\\", \\\"courtyardproperties\\\", \\\"criteriaproperties\\\", \\\"ctrcos\\\", \\\"dcslmgmt\\\", \\\"delshah\\\", \\\"discala\\\", \\\"dolphinrealestate\\\", \\\"dover\\\", \\\"dphaurora\\\", \\\"duopropertymanagement\\\", \\\"duval\\\", \\\"ebrmanagement\\\", \\\"elevatesdproperties\\\", \\\"elkal\\\", \\\"encompassmgmt\\\", \\\"eqre\\\", \\\"equilibriumprops\\\", \\\"esa\\\", \\\"firstequityassociates\\\", \\\"firstw\\\", \\\"fivepnhholdingcompany\\\", \\\"gibson\\\", \\\"gorealtyco\\\", \\\"grindstone\\\", \\\"guerrette\\\", \\\"hammerandsaw\\\", \\\"hampshire\\\", \\\"harlamert\\\", \\\"headwayhomes\\\", \\\"heymingandjohnson\\\", \\\"hpmgmtinc\\\", \\\"ihacommercial\\\", \\\"iharesidential\\\", \\\"illicre\\\", \\\"investorspmgroup\\\", \\\"investwest\\\", \\\"jaasopm\\\", \\\"josephcompanies\\\", \\\"k3mgmt\\\", \\\"keenermanagement\\\", \\\"kelemencompany\\\", \\\"kfgpropertiesinc\\\", \\\"kiermgmt\\\", \\\"kinselameri\\\", \\\"kodiakpm\\\", \\\"land\\\", \\\"lapmg\\\", \\\"libertyproperties\\\", \\\"lmt\\\", \\\"lynxproperty\\\", \\\"madisonhill\\\", \\\"marathon\\\", \\\"marshallperry\\\", \\\"mccrealty\\\", \\\"mdatkinson\\\", \\\"meridiapm\\\", \\\"mgiglobal\\\", \\\"monroeavenue\\\", \\\"motwoprop\\\", \\\"mpminc\\\", \\\"mpsmanagement\\\", \\\"mtdpropertym\\\", \\\"mth\\\", \\\"murphyproperties\\\", \\\"nai1stvalley\\\", \\\"nautilus\\\", \\\"ncm\\\", \\\"nelsonminahanrealtors\\\", \\\"nexus\\\", \\\"nido\\\", \\\"nieblerproperties\\\", \\\"northwestmanagement\\\", \\\"northwoodproperties\\\", \\\"otp\\\", \\\"parkplacemgmt\\\", \\\"pghnexus\\\", \\\"phillipsre\\\", \\\"pillarrei\\\", \\\"pingreenw\\\", \\\"pm0vacancy\\\", \\\"podmajersky\\\", \\\"port\\\", \\\"prdcproperties\\\", \\\"premierres\\\", \\\"propertyhill\\\", \\\"quorumrealestate\\\", \\\"ralstonmgmt\\\", \\\"randpmllc\\\", \\\"redgroupny\\\", \\\"redside\\\", \\\"reichlekleingroup\\\", \\\"revisiongroup\\\", \\\"rhamco1\\\", \\\"robartsproperties\\\", \\\"rockproperties\\\", \\\"rocktownrealty\\\", \\\"roostdcllc\\\", \\\"rpmco007\\\", \\\"rpmne004\\\", \\\"sagepm\\\", \\\"scopeprops\\\", \\\"sdaptbrokers\\\", \\\"sdpropmgt\\\", \\\"sierraranch\\\", \\\"silverleafpmgmt\\\", \\\"skylinenewyork\\\", \\\"spectraassociates\\\", \\\"starmetro\\\", \\\"stephensargent\\\", \\\"sternproperty\\\", \\\"stratford\\\", \\\"sunrisemgmt\\\", \\\"thecoralcompany\\\", \\\"thelestergroup\\\", \\\"theschippergroup\\\", \\\"thewildcatgroup\\\", \\\"thosdwalsh\\\", \\\"threelestate\\\", \\\"tiaoproperties\\\", \\\"tmmrealestate\\\", \\\"trilliant\\\", \\\"trionprop\\\", \\\"turnstone\\\", \\\"uniquesolutions\\\", \\\"urbanhiveproperties\\\", \\\"urbankey\\\", \\\"utopiahoamanagement\\\", \\\"utopiamanagement\\\", \\\"valcorcre\\\", \\\"valleyincomeprop\\\", \\\"valstockmanagement\\\", \\\"vanguardpropertygroup\\\", \\\"vesacommercial\\\", \\\"virtuousmg\\\", \\\"volunteerproperties\\\", \\\"vpmi\\\", \\\"wallspropmgmt\\\", \\\"waltarnold\\\", \\\"wayfinder\\\", \\\"whalenproperties\\\", \\\"whitmoremanagementllc\\\", \\\"winstarproperties\\\", \\\"woodmont\\\", \\\"wooldridge\\\"]"
+
+# Coldstart
+add_variables invoice_processing_coldstart_counter 0
+add_variables invoice_processing_coldstart_sha 4776aa617c763f4f984cb2c5c9aa48381230b912
+add_variables invoice_processing_coldstart_vhosts "[\\\"allied\\\"]"
+
+# Experiments
+add_variables invoice_processing_experiments_always_train	True
+add_variables invoice_processing_experiments_counter	0
+add_variables invoice_processing_experiments_sha    4776aa617c763f4f984cb2c5c9aa48381230b912
+add_variables invoice_processing_experiments_vhosts "[\\\"allied\\\"]"
+
+# Tester
+add_variables invoice_processing_experiments_tester_always_train	True
+add_variables invoice_processing_experiments_tester_counter	0
+add_variables invoice_processing_experiments_tester_sha    4776aa617c763f4f984cb2c5c9aa48381230b912
+add_variables invoice_processing_experiments_tester_vhosts "[\\\"allied\\\"]"
+
+# Manual
+add_variables invoice_processing_manual_always_train	True
+add_variables invoice_processing_manual_counter	0
+add_variables invoice_processing_manual_sha	4776aa617c763f4f984cb2c5c9aa48381230b912
+add_variables invoice_processing_manual_vhosts	"[\\\"allied\\\"]"
+
+# reference
+add_variables invoice_processing_reference_counter	0
+add_variables invoice_processing_reference_sha	453daad491d5a905fa654b86fe584787466735ba
+add_variables invoice_processing_reference_vhosts "[\\\"actprop\\\", \\\"arthurthomas\\\", \\\"az1strealty\\\", \\\"baboudjianprop\\\", \\\"bandz\\\", \\\"blanchardandcalhoun\\\", \\\"brownstonemgt\\\", \\\"calson\\\", \\\"cavaliermgmt\\\", \\\"circum\\\", \\\"coastlineequity\\\", \\\"criteriaproperties\\\", \\\"discala\\\", \\\"duval\\\", \\\"ebrmanagement\\\", \\\"equilibriumprops\\\", \\\"hpmgmtinc\\\", \\\"ihacommercial\\\", \\\"investorspmgroup\\\", \\\"jaasopm\\\", \\\"keenermanagement\\\", \\\"land\\\", \\\"marshallperry\\\", \\\"meridiapm\\\", \\\"monroeavenue\\\", \\\"mpminc\\\", \\\"ncm\\\", \\\"premierres\\\", \\\"quorumrealestate\\\", \\\"ram\\\", \\\"randpmllc\\\", \\\"revisiongroup\\\", \\\"silverleafpmgmt\\\", \\\"starmetro\\\", \\\"thecoralcompany\\\", \\\"thelestergroup\\\", \\\"thosdwalsh\\\", \\\"trionprop\\\", \\\"valleyincomeprop\\\", \\\"virtuousmg\\\", \\\"winstarproperties\\\"]"
+
+######################################
+# Add connections to airflow
+######################################
+
+# Insert slack oauth
+kubectl --namespace ${NAMESPACE} exec ${AIRFLOW_POD} -c webserver -- sh -c "/entrypoint.sh airflow connections --add --conn_id slack_connection_airflow --conn_type http --conn_password ${SLACK_OAUTH}"
+

--- a/install/custom_values.yaml
+++ b/install/custom_values.yaml
@@ -1,0 +1,52 @@
+airflow:
+  # Don't use this fernet key in production!
+  fernet_key: "wEyDkTXKeSZNfNMhwrPMjSPY-E4UJEx8GtN5QV3nTkM="
+  image:
+    repository: dafrenchyman/docker-airflow
+    tag: 1.10.2
+    pull_policy: Always
+  config:
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "True"
+    AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: "300"
+    AIRFLOW__CORE__DEFAULT_TIMEZONE: "America/Los_Angeles"
+    AIRFLOW__CORE__SQL_ALCHEMY_POOL_SIZE: "0"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
+    AIRFLOW__WEBSERVER__DAG_DEFAULT_VIEW: "graph"
+  logs:
+    persistence:
+      existingClaim: nfs-airflow-logs
+  dags:
+    persistence:
+      enabled: false  # Persistence must be disabled when using git-sync
+    git:
+      # Play around with different repositories, branches and subpaths
+      # subpath is the relative directory path in the git repository where
+      # the dags can be found.
+      url: https://github.com/dafrenchyman/kube
+      #url: https://github.com/apache/airflow
+      branch: master
+      # subpath: airflow/example_dags # .
+      subpath: .
+  rbac:
+    enabled: false
+    # Initial rbac users can be defined here as a list of maps.
+    users:
+    - firstname: "AI"
+      lastname: "Tiger"
+      email: "ai.of.the.tiger@appfolio.com"
+      username: "admin"
+      role: "Admin"
+      password: "airflow123"
+
+
+ingress:
+  enabled: false
+
+postgresql:
+  enabled: true
+  postgresUser: postgres
+  postgresPassword: airflow123
+  postgresDatabase: airflow
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce

--- a/install/delete_completed_pods.sh
+++ b/install/delete_completed_pods.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export PODS_TO_DELETE=`kubectl get pods | grep -e Completed -e Error -e ImagePullBackOff | awk '{print $1}'`
+for i in "${PODS_TO_DELETE[@]}"
+do
+  kubectl delete pods $i
+done

--- a/install/port_forwarding.sh
+++ b/install/port_forwarding.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+NAMESPACE=$1
+: "${NAMESPACE:="default"}"
+
+set -x
+
+killall kubectl
+sleep 1
+rm nohup.out
+
+AIRFLOW_POD=`kubectl get pod --namespace ${NAMESPACE} --selector="app=airflow-web,release=airflow" --output jsonpath='{.items[0].metadata.name}'`
+AIRFLOW_PORT=8080
+
+nohup kubectl port-forward --namespace ${NAMESPACE} ${AIRFLOW_POD} ${AIRFLOW_PORT}:${AIRFLOW_PORT} &
+

--- a/nfs/create_nfs_logs.sh
+++ b/nfs/create_nfs_logs.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+NAMESPACE=$1
+: "${NAMESPACE:="default"}"
+
 set -e
 
-NAMESPACE=airflow
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 WAIT_SECONDS=3
 

--- a/nfs/delete_nfs.sh
+++ b/nfs/delete_nfs.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+NAMESPACE=$1
+: "${NAMESPACE:="default"}"
+
 set -e
 
-NAMESPACE=airflow
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 WAIT_SECONDS=3
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+NAMESPACE=$1
+: "${NAMESPACE:="default"}"
+
+##############################################################
+# Function to remove airflow from kubernetes cluster
+##############################################################
+uninstall_airflow() {
+
+  # Remove port forwarding
+  PORT_FORWARD_PROCESS=`ps -ef | grep "kubectl port-forward " | grep -v "grep" | awk '{ print $2 }'`
+  if [ -z "$PORT_FORWARD_PROCESS" ]; then
+    echo "No port-forward process running"
+  else
+    echo "Killing process ${PORT_FORWARD_PROCESS} to end port-forwarding"
+    kill ${PORT_FORWARD_PROCESS}
+  fi
+
+  # Uninstall airflow via helm
+  helm delete --purge airflow
+  echo "Waiting 10 seconds for services to shut down"
+  sleep 10
+
+  # Remove pods that refuse to go away
+  export AIRFLOW_TO_PURGE=`kubectl get pods | grep airflow | cut -f1 -d' '`
+  for i in "${AIRFLOW_TO_PURGE[@]}"
+  do
+    echo "Purging: ${i}"
+    kubectl delete pods $i --grace-period=0 --force
+  done
+
+  # Delete airflow service account
+  kubectl --namespace=${NAMESPACE} delete clusterrolebinding airflow
+  kubectl --namespace=${NAMESPACE} delete serviceaccount airflow --namespace=${NAMESPACE}
+
+  # Delete secrets
+  kubectl --namespace=${NAMESPACE} delete secret invoice-processing-env
+  kubectl --namespace=${NAMESPACE} delete secret invoice-processing-google-app-cred
+  kubectl --namespace=${NAMESPACE} delete secret invoice-processing-invoice-processing-ocr-creds
+  kubectl --namespace=${NAMESPACE} delete secret invoice-processing-ocr-compress
+
+  # Remove the logging service
+  ./nfs/delete_nfs.sh ${NAMESPACE}
+
+  #kubectl delete -n ${NAMESPACE} deployment nfs-server
+  #kubectl --namespace ${NAMESPACE} delete service nfs-server
+}
+
+
+uninstall_airflow


### PR DESCRIPTION
When an Airflow kube worker tries to get an Airflow variable, it fails because it wasn't able top decrypt it. I actually had to change the the `delete_worker_pods` under `[kubernetes]` in the airflow config to see what the error was.

Adding these secrets to the config fixed it.