### PR TITLE
Fixed an issue with the `FERNET_KEY` not being available for the airflow worker pods

### DIFF
--- a/airflow/templates/configmaps.yaml
+++ b/airflow/templates/configmaps.yaml
@@ -160,7 +160,9 @@ data:
 
     [kubernetes_secrets]
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = {{ template "airflow.fullname" $ }}-env=AIRFLOW__CORE__SQL_ALCHEMY_CONN
+    AIRFLOW__CORE__FERNET_KEY = {{ template "airflow.fullname" $ }}-env=FERNET_KEY
     AIRFLOW_HOME = {{ template "airflow.fullname" $ }}-env=AIRFLOW_HOME
+    FERNET_KEY = {{ template "airflow.fullname" $ }}-env=FERNET_KEY
     {{- range $setting, $option := .Values.airflow.config }}
     {{ $setting }} = {{ template "airflow.fullname" $ }}-env={{ $setting }}
     {{- end }}


### PR DESCRIPTION
Here's *just* the PR concerning the fix.

When an Airflow kube worker tries to get an Airflow variable, it fails because it wasn't able top decrypt it. I actually had to change the the delete_worker_pods under [kubernetes] in the airflow config to see what the error was.

Adding these secrets to the config fixed it.